### PR TITLE
fix: add generic-types for some functions

### DIFF
--- a/src/builders/form.ts
+++ b/src/builders/form.ts
@@ -1,9 +1,13 @@
 import { BasicBuilder } from './basic';
-import { $FieldSetValue, FormModel } from '../models';
+import { $FieldSetValue, FormModel, BasicModel } from '../models';
 import { $FieldSetBuilderChildren } from './set';
 import { Maybe, Some, or } from '../maybe';
 
-export class FormBuilder<ChildBuilders extends Record<string, BasicBuilder<any, any>>> extends BasicBuilder<
+export class FormBuilder<
+  ChildBuilders extends Record<string, Builder>,
+  Builder extends BasicBuilder<any, Model>,
+  Model extends BasicModel<any>
+> extends BasicBuilder<
   $FieldSetValue<$FieldSetBuilderChildren<ChildBuilders>>,
   FormModel<$FieldSetBuilderChildren<ChildBuilders>>
 > {

--- a/src/builders/form.ts
+++ b/src/builders/form.ts
@@ -5,8 +5,8 @@ import { Maybe, Some, or } from '../maybe';
 
 export class FormBuilder<
   ChildBuilders extends Record<string, Builder>,
-  Builder extends BasicBuilder<any, Model>,
-  Model extends BasicModel<any>
+  Builder extends BasicBuilder<unknown, Model>,
+  Model extends BasicModel<unknown>
 > extends BasicBuilder<
   $FieldSetValue<$FieldSetBuilderChildren<ChildBuilders>>,
   FormModel<$FieldSetBuilderChildren<ChildBuilders>>
@@ -17,7 +17,7 @@ export class FormBuilder<
 
   build(defaultValues?: Maybe<$FieldSetValue<$FieldSetBuilderChildren<ChildBuilders>>>) {
     const defaults = or<Record<keyof ChildBuilders, any>>(defaultValues, {} as $FieldSetValue<$FieldSetBuilderChildren<ChildBuilders>>);
-    const children = {} as $FieldSetValue<$FieldSetBuilderChildren<ChildBuilders>>;
+    const children = {} as $FieldSetBuilderChildren<ChildBuilders>;
     const childKeys: Array<keyof ChildBuilders> = Object.keys(this._childBuilders);
     for (let i = 0; i < childKeys.length; i += 1) {
       const key = childKeys[i];

--- a/src/builders/index.ts
+++ b/src/builders/index.ts
@@ -11,10 +11,18 @@ export * from './set';
 export * from './form';
 export * from './basic';
 
+/**
+ * 创建一个 `Field` builder
+ * @param defaultValue `Field` 的默认值
+ */
 export function field<T>(defaultValue: T) {
   return new FieldBuilder(defaultValue);
 }
 
+/**
+ * 创建一个 `FieldArray` builder
+ * @param childBuilder 数组元素的 builder 对象，可以是 `field`、`array` 或者 `set` 的返回值
+ */
 export function array<ChildBuilder extends BasicBuilder<any, any>>(
   childBuilder: ChildBuilder,
 ) {

--- a/src/builders/index.ts
+++ b/src/builders/index.ts
@@ -23,16 +23,16 @@ export function array<ChildBuilder extends BasicBuilder<any, any>>(
 
 export function set<
   ChildBuilders extends Record<string, Builder>,
-  Builder extends BasicBuilder<any, Model>,
-  Model extends BasicModel<any>
+  Builder extends BasicBuilder<unknown, Model>,
+  Model extends BasicModel<unknown>
 >(childBuilders: ChildBuilders) {
   return new FieldSetBuilder<ChildBuilders>(childBuilders);
 }
 
 export function form<
   ChildBuilders extends Record<string, Builder>,
-  Builder extends BasicBuilder<any, Model>,
-  Model extends BasicModel<any>
+  Builder extends BasicBuilder<unknown, Model>,
+  Model extends BasicModel<unknown>
 >(childBuilders: ChildBuilders) {
   return new FormBuilder<ChildBuilders, Builder, Model>(childBuilders);
 }

--- a/src/builders/index.ts
+++ b/src/builders/index.ts
@@ -21,6 +21,10 @@ export function array<ChildBuilder extends BasicBuilder<any, any>>(
   return new FieldArrayBuilder<ChildBuilder>(childBuilder);
 }
 
+/**
+ * 创建一个 `FieldSet` builder
+ * @param childBuilders `FieldSet` 每个字段对应的 builder 对象，其值可以是 `field`、`array` 或者 `set` 的返回值
+ */
 export function set<
   ChildBuilders extends Record<string, Builder>,
   Builder extends BasicBuilder<unknown, Model>,
@@ -29,6 +33,10 @@ export function set<
   return new FieldSetBuilder<ChildBuilders>(childBuilders);
 }
 
+/**
+ * 创建一个 `Form` builder，是最顶层的 builder 对象
+ * @param childBuilders `Form` 每个字段对应的 builder 对象，其值可以是 `field`、`array` 或者 `set` 的返回值
+ */
 export function form<
   ChildBuilders extends Record<string, Builder>,
   Builder extends BasicBuilder<unknown, Model>,

--- a/src/builders/index.ts
+++ b/src/builders/index.ts
@@ -3,6 +3,7 @@ import { FieldBuilder } from './field';
 import { FieldSetBuilder } from './set';
 import { BasicBuilder } from './basic';
 import { FormBuilder } from './form';
+import { BasicModel } from '../models';
 
 export * from './array';
 export * from './field';
@@ -20,10 +21,18 @@ export function array<ChildBuilder extends BasicBuilder<any, any>>(
   return new FieldArrayBuilder<ChildBuilder>(childBuilder);
 }
 
-export function set<ChildBuilders extends Record<string, BasicBuilder<any, any>>>(childBuilders: ChildBuilders) {
+export function set<
+  ChildBuilders extends Record<string, Builder>,
+  Builder extends BasicBuilder<any, Model>,
+  Model extends BasicModel<any>
+>(childBuilders: ChildBuilders) {
   return new FieldSetBuilder<ChildBuilders>(childBuilders);
 }
 
-export function form<ChildBuilders extends Record<string, BasicBuilder<any, any>>>(childBuilders: ChildBuilders) {
-  return new FormBuilder<ChildBuilders>(childBuilders);
+export function form<
+  ChildBuilders extends Record<string, Builder>,
+  Builder extends BasicBuilder<any, Model>,
+  Model extends BasicModel<any>
+>(childBuilders: ChildBuilders) {
+  return new FormBuilder<ChildBuilders, Builder, Model>(childBuilders);
 }

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -9,8 +9,12 @@ export interface IForm<T extends Record<string, BasicModel<unknown>>> {
   model: FormModel<T>;
 }
 
-export function useForm<T extends Record<string, BasicBuilder<unknown, BasicModel<unknown>>>>(
-  arg: FormStrategy.View | FormBuilder<T>,
+export function useForm<
+  T extends Record<string, Builder>,
+  Builder extends BasicBuilder<any, Model>,
+  Model extends BasicModel<any>
+>(
+  arg: FormStrategy.View | FormBuilder<T, Builder, Model>,
 ): IForm<$FieldSetBuilderChildren<T>> {
   return useMemo(() => {
     let strategy: FormStrategy;

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -11,8 +11,8 @@ export interface IForm<T extends Record<string, BasicModel<unknown>>> {
 
 export function useForm<
   T extends Record<string, Builder>,
-  Builder extends BasicBuilder<any, Model>,
-  Model extends BasicModel<any>
+  Builder extends BasicBuilder<unknown, Model>,
+  Model extends BasicModel<unknown>
 >(
   arg: FormStrategy.View | FormBuilder<T, Builder, Model>,
 ): IForm<$FieldSetBuilderChildren<T>> {

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -9,6 +9,11 @@ export interface IForm<T extends Record<string, BasicModel<unknown>>> {
   model: FormModel<T>;
 }
 
+/**
+ * 创建一个 `Form`
+ * 
+ * @param arg 指定一个 builder 对象来显式构造表单数据，或者指定 `FormStrategy.View` 自动根据视图构造表单数据
+ */
 export function useForm<
   T extends Record<string, Builder>,
   Builder extends BasicBuilder<unknown, Model>,

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -11,7 +11,7 @@ enum FormStrategy {
 const FORM_ID = Symbol('form');
 
 class FormModel<
-  Children extends Record<string, BasicModel<any>> = Record<string, BasicModel<any>>
+  Children extends Record<string, BasicModel<unknown>> = Record<string, BasicModel<unknown>>
 > extends FieldSetModel<Children> {
   /**
    * @internal


### PR DESCRIPTION
useForm在使用时会报类型错误，由于当前版本的泛型里写死了BasicBuilder和BasicModel，使用者传入比如FieldModel这样的子类型时不能兼容，因此加入了泛型参数Builder和Model，已在项目中应用改动验证过