### PR TITLE
feature: model增加isVisible属性

### DIFF
--- a/dev.tsx
+++ b/dev.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import * as ReactDOM from 'react-dom';
 
 import {
@@ -127,6 +127,7 @@ const FieldSet = ({
 const App = () => {
   const form = useForm(FormStrategy.View);
   // const isValidating = useValue$(form.isValidating$, false);
+  const [input1, toggleInput1] = useState(true);
   console.log('App render');
   return (
     <FormProvider value={form.ctx}>
@@ -136,7 +137,7 @@ const App = () => {
           <Input key={index} name={`input${index}`} />
         ))} */}
       <FieldSet name="fieldset">
-        <Input field="input1" />
+        {input1 && <Input field="input1" />}
         <FieldValue name="input1" />
         <Input field="input2" />
       </FieldSet>
@@ -156,6 +157,10 @@ const App = () => {
         >
           validate
         </button>
+        <button onClick={() => {
+          console.log(form.model.getVisibleValue())
+        }}>getVisibleValue</button>
+        <button onClick={() => toggleInput1(v => !v)}>toggle input1</button>
       </div>
     </FormProvider>
   );

--- a/src/field-array.tsx
+++ b/src/field-array.tsx
@@ -10,7 +10,7 @@ import {
   isFieldArrayModel,
 } from './models';
 import { useFormContext } from './context';
-import { useValue$ } from './hooks';
+import { useValue$, useVisible } from './hooks';
 import { removeOnUnmount } from './utils';
 import { isSome, get } from './maybe';
 import { IValidators } from './validate';
@@ -113,6 +113,7 @@ export function useFieldArray<Item, Child extends BasicModel<Item>>(
    */
   useValue$(children$, children$.getValue());
   useValue$(error$, error$.getValue());
+  useVisible(model);
   removeOnUnmount(field, model, parent);
   return model;
 }

--- a/src/field-set.tsx
+++ b/src/field-set.tsx
@@ -9,7 +9,7 @@ import {
   isModelRef,
   isFieldSetModel,
 } from './models';
-import { useValue$ } from './hooks';
+import { useValue$, useVisible } from './hooks';
 import { IValidators } from './validate';
 import { removeOnUnmount, isPlainObject } from './utils';
 import { isSome, get, or } from './maybe';
@@ -90,6 +90,7 @@ export function useFieldSet<T extends Record<string, BasicModel<any>>>(
    * user can get the value from model
    */
   useValue$(model.error$, model.error$.getValue());
+  useVisible(model);
   removeOnUnmount(field, model, parent);
   return [childContext, model];
 }

--- a/src/field.tsx
+++ b/src/field.tsx
@@ -9,7 +9,7 @@ import {
   isModelRef,
   isFieldModel,
 } from './models';
-import { useValue$ } from './hooks';
+import { useValue$, useVisible } from './hooks';
 import { useFormContext } from './context';
 import { IValidators } from './validate';
 import { removeOnUnmount } from './utils';
@@ -52,7 +52,6 @@ function useModelAndChildProps<Value>(
   }, [field, parent, strategy, form]);
 }
 
-
 /**
  * 创建一个 `Field`
  * 
@@ -86,6 +85,7 @@ export function useField<Value>(
   if (typeof field === 'string' || isModelRef(field)) {
     model.validators = validators;
   }
+  useVisible(model);
   removeOnUnmount(field, model, parent);
   return model;
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -22,6 +22,7 @@ export function useVisible<T>(model: BasicModel<T>) {
     model.isVisible = true;
     return () => {
       model.isVisible = false;
+      console.log(model.isVisible)
     };
   }, []);
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Observable } from 'rxjs';
+import { BasicModel } from './models';
 
 export function useValue$<T>(value$: Observable<T>, initialValue: T) {
   const [value, setValue] = useState(initialValue);
@@ -14,4 +15,13 @@ export function useEffect$<T>(event$: Observable<T>, effect: (e: T) => void) {
     const $ = event$.subscribe(effect);
     return () => $.unsubscribe();
   }, [event$]);
+}
+
+export function useVisible<T>(model: BasicModel<T>) {
+  useEffect(() => {
+    model.isVisible = true;
+    return () => {
+      model.isVisible = false;
+    };
+  }, []);
 }

--- a/src/models/array.ts
+++ b/src/models/array.ts
@@ -107,6 +107,10 @@ class FieldArrayModel<Item, Child extends BasicModel<Item> = BasicModel<Item>> e
     });
   }
 
+  getVisibleValue() {
+    return this.isVisible ? this.getRawValue() : undefined;
+  }
+
   /**
    * 修改 `FieldArray` 的值
    * @param value 要修改的值

--- a/src/models/basic.ts
+++ b/src/models/basic.ts
@@ -65,6 +65,7 @@ abstract class BasicModel<Value> implements IModel<Value> {
 
   abstract getRawValue(): any;
   abstract getSubmitValue(): any;
+  abstract getVisibleValue(): any;
 
   readonly error$ = new BehaviorSubject<IMaybeError<Value>>(null);
 

--- a/src/models/basic.ts
+++ b/src/models/basic.ts
@@ -66,7 +66,7 @@ abstract class BasicModel<Value> implements IModel<Value> {
   abstract validate(option?: ValidateOption): Promise<any>;
 
   protected triggerValidate(option: ValidateOption) {
-    return new Promise((resolve, reject) => {
+    return new Promise<IMaybeError<Value>>((resolve, reject) => {
       this.validate$.next({
         option,
         resolve,

--- a/src/models/basic.ts
+++ b/src/models/basic.ts
@@ -55,6 +55,11 @@ abstract class BasicModel<Value> implements IModel<Value> {
    */
   destroyOnUnmount = false;
 
+  /**
+   * model对应的组件是否被渲染
+   */
+  isVisible = false;
+
   /** @internal */
   [MODEL_ID]!: boolean;
 

--- a/src/models/field.ts
+++ b/src/models/field.ts
@@ -85,6 +85,10 @@ class FieldModel<Value> extends BasicModel<Value> {
     return normalizeBeforeSubmit(this.value$.getValue());
   }
 
+  getVisibleValue() {
+    return this.isVisible ? this.getRawValue() : undefined;
+  }
+
   /**
    * `Field` 是否所有校验都通过了
    */

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -30,11 +30,7 @@ class FormModel<
   validate(option?: ValidateIncludingChildrenRecursively): Promise<IMaybeError<any>[]>
   validate(option: ValidateExcludingChildrenRecursively): Promise<IMaybeError<any>>
   validate(option: ValidateOption = ValidateOption.Default) {
-    if (option === ValidateOption.IncludeChildrenRecursively || option === ValidateOption.Default) {
-      return super.validate(option);
-    } else {
-      return super.validate(option);
-    }
+    return super.validate(option | ValidateOption.IncludeChildrenRecursively) as unknown;
   }
 
   /** @internal */

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, Observable } from 'rxjs';
-import { FieldSetModel } from './set';
+import { FieldSetModel, ValidateIncludingChildrenRecursively, ValidateExcludingChildrenRecursively } from './set';
 import { BasicModel } from './basic';
-import { ValidateOption } from '../validate';
+import { ValidateOption, IMaybeError } from '../validate';
 
 enum FormStrategy {
   Model,
@@ -27,8 +27,14 @@ class FormModel<
     this.form = this;
   }
 
+  validate(option?: ValidateIncludingChildrenRecursively): Promise<IMaybeError<any>[]>
+  validate(option: ValidateExcludingChildrenRecursively): Promise<IMaybeError<any>>
   validate(option: ValidateOption = ValidateOption.Default) {
-    return super.validate(option | ValidateOption.IncludeChildrenRecursively);
+    if (option === ValidateOption.IncludeChildrenRecursively || option === ValidateOption.Default) {
+      return super.validate(option);
+    } else {
+      return super.validate(option);
+    }
   }
 
   /** @internal */

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -35,7 +35,6 @@ class FormModel<
 
   /** @internal */
   addWorkingValidator(v: Observable<unknown>) {
-    const r = this.validate(ValidateOption.ExcludePristine);
     this.workingValidators.add(v);
     this.updateIsValidating();
   }

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -27,8 +27,7 @@ class FormModel<
     this.form = this;
   }
 
-  validate(option?: ValidateIncludingChildrenRecursively): Promise<IMaybeError<any>[]>
-  validate(option: ValidateExcludingChildrenRecursively): Promise<IMaybeError<any>>
+  validate(option?: ValidateOption): Promise<IMaybeError<any> | IMaybeError<any>[]>
   validate(option: ValidateOption = ValidateOption.Default) {
     return super.validate(option | ValidateOption.IncludeChildrenRecursively) as unknown;
   }

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -1,5 +1,5 @@
 import { BehaviorSubject, Observable } from 'rxjs';
-import { FieldSetModel, ValidateIncludingChildrenRecursively, ValidateExcludingChildrenRecursively } from './set';
+import { FieldSetModel } from './set';
 import { BasicModel } from './basic';
 import { ValidateOption, IMaybeError } from '../validate';
 

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -27,7 +27,6 @@ class FormModel<
     this.form = this;
   }
 
-  validate(option?: ValidateOption): Promise<IMaybeError<any> | IMaybeError<any>[]>
   validate(option: ValidateOption = ValidateOption.Default) {
     return super.validate(option | ValidateOption.IncludeChildrenRecursively);
   }

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -28,6 +28,7 @@ class FormModel<
   /** @internal */
   private readonly workingValidators = new Set<Observable<unknown>>();
   readonly isValidating$ = new BehaviorSubject(false);
+  isVisible = true;
 
   constructor(public readonly children: Children) {
     super(children);

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -35,6 +35,7 @@ class FormModel<
 
   /** @internal */
   addWorkingValidator(v: Observable<unknown>) {
+    const r = this.validate(ValidateOption.ExcludePristine);
     this.workingValidators.add(v);
     this.updateIsValidating();
   }

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 import { FieldSetModel } from './set';
 import { BasicModel } from './basic';
-import { ValidateOption, IMaybeError } from '../validate';
+import { ValidateOption } from '../validate';
 
 enum FormStrategy {
   Model,

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -29,7 +29,7 @@ class FormModel<
 
   validate(option?: ValidateOption): Promise<IMaybeError<any> | IMaybeError<any>[]>
   validate(option: ValidateOption = ValidateOption.Default) {
-    return super.validate(option | ValidateOption.IncludeChildrenRecursively) as unknown;
+    return super.validate(option | ValidateOption.IncludeChildrenRecursively);
   }
 
   /** @internal */

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -102,14 +102,18 @@ class FieldSetModel<
    * 获取当前已被渲染的组件的表单值
    */
   getVisibleValue() {
+    if (!this.isVisible) {
+      return;
+    }
     const value: any = {};
     const keys = Object.keys(this.children);
     const len = keys.length;
     for (let i = 0; i < len; i++) {
       const key = keys[i];
       const model = this.children[key];
+      console.log(key, model.isVisible)
       if (model.isVisible) {
-        value[key] = model.getRawValue();
+        value[key] = model.getVisibleValue();
       }
     }
     return value as DeepPartial<$FieldSetValue<Children>>;

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -153,6 +153,10 @@ class FieldSetModel<
     }
   }
 
+  /**
+   * 执行 `FieldSet` 的校验
+   * @param option 校验的参数
+   */
   validate(option = ValidateOption.Default): Promise<IMaybeError<any> | IMaybeError<any>[]> {
     if (option & ValidateOption.IncludeChildrenRecursively) {
       return Promise.all<IMaybeError<any>>(

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -8,9 +8,6 @@ type $FieldSetValue<Children extends Record<string, BasicModel<any>>> = {
   [Key in keyof Children]: Children[Key]['phantomValue'];
 };
 
-export type ValidateIncludingChildrenRecursively = Extract<ValidateOption, ValidateOption.IncludeChildrenRecursively | ValidateOption.Default>;
-export type ValidateExcludingChildrenRecursively = Exclude<ValidateOption, ValidateOption.IncludeChildrenRecursively | ValidateOption.Default>;
-
 const SET_ID = Symbol('set');
 
 class FieldSetModel<
@@ -156,8 +153,7 @@ class FieldSetModel<
     }
   }
 
-  validate(option?: ValidateIncludingChildrenRecursively): Promise<IMaybeError<any>[]>
-  validate(option: ValidateExcludingChildrenRecursively): Promise<IMaybeError<any>>
+  validate(option?: ValidateOption): Promise<IMaybeError<any>[] | IMaybeError<any>>
   validate(option = ValidateOption.Default) {
     if (option & ValidateOption.IncludeChildrenRecursively) {
       return Promise.all<IMaybeError<any>>(

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -153,8 +153,7 @@ class FieldSetModel<
     }
   }
 
-  validate(option?: ValidateOption): Promise<IMaybeError<any>[] | IMaybeError<any>>
-  validate(option = ValidateOption.Default) {
+  validate(option = ValidateOption.Default): Promise<IMaybeError<any> | IMaybeError<any>[]> {
     if (option & ValidateOption.IncludeChildrenRecursively) {
       return Promise.all<IMaybeError<any>>(
         Object.keys(this.children)

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -3,6 +3,7 @@ import { BasicModel, isModel } from './basic';
 import { ValidateOption, IMaybeError } from '../validate';
 import { Some, Maybe, None } from '../maybe';
 import { isPlainObject } from '../utils';
+import { DeepPartial } from 'utility-types';
 
 type $FieldSetValue<Children extends Record<string, BasicModel<any>>> = {
   [Key in keyof Children]: Children[Key]['phantomValue'];
@@ -95,6 +96,23 @@ class FieldSetModel<
       value[key] = childValue;
     }
     return value;
+  }
+
+  /**
+   * 获取当前已被渲染的组件的表单值
+   */
+  getVisibleValue() {
+    const value: any = {};
+    const keys = Object.keys(this.children);
+    const len = keys.length;
+    for (let i = 0; i < len; i++) {
+      const key = keys[i];
+      const model = this.children[key];
+      if (model.isVisible) {
+        value[key] = model.getRawValue();
+      }
+    }
+    return value as DeepPartial<$FieldSetValue<Children>>;
   }
 
   /**

--- a/src/models/set.ts
+++ b/src/models/set.ts
@@ -11,7 +11,7 @@ type $FieldSetValue<Children extends Record<string, BasicModel<any>>> = {
 export type ValidateIncludingChildrenRecursively = Extract<ValidateOption, ValidateOption.IncludeChildrenRecursively | ValidateOption.Default>;
 export type ValidateExcludingChildrenRecursively = Exclude<ValidateOption, ValidateOption.IncludeChildrenRecursively | ValidateOption.Default>;
 
-const SET = Symbol('set');
+const SET_ID = Symbol('set');
 
 class FieldSetModel<
   Children extends Record<string, BasicModel<any>> = Record<string, BasicModel<any>>
@@ -19,7 +19,7 @@ class FieldSetModel<
   /**
    * @internal
    */
-  [SET]!: boolean;
+  [SET_ID]!: boolean;
 
   /** @internal */
   patchedValue: $FieldSetValue<Children> | null = null;
@@ -202,12 +202,12 @@ class FieldSetModel<
   }
 }
 
-FieldSetModel.prototype[SET] = true;
+FieldSetModel.prototype[SET_ID] = true;
 
 function isFieldSetModel<Children extends Record<string, BasicModel<any>> = Record<string, BasicModel<any>>>(
   maybeModel: any,
 ): maybeModel is FieldSetModel<Children> {
-  return !!(maybeModel && maybeModel[SET]);
+  return !!(maybeModel && maybeModel[SET_ID]);
 }
 
 export { FieldSetModel, $FieldSetValue, isFieldSetModel };

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -59,7 +59,7 @@ export enum ValidateOption {
 
 export interface IValidation {
   option: ValidateOption;
-  resolve(error: IMaybeError<any>): void;
+  resolve(error?: IMaybeError<any>): void;
   reject(error?: any): void;
 }
 
@@ -152,7 +152,7 @@ class ValidatorExecutor<T> {
         return empty();
       }),
       tap(resolve),
-      finalize(() => resolve(null)),
+      finalize(resolve),
     );
   }
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -133,11 +133,11 @@ class ValidatorExecutor<T> {
   call(validation: IValidation): Observable<IMaybeError<T>> {
     const { option, reject, resolve } = validation;
     if (!this.model.touched() && !(option & ValidateOption.IncludeUntouched)) {
-      resolve(null);
+      resolve();
       return of(null);
     }
     if (option & ValidateOption.ExcludePristine && this.model.pristine()) {
-      resolve(null);
+      resolve();
       return of(null);
     }
     const value = this.model.getRawValue();

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -44,7 +44,7 @@ export interface IValidateResult<T> {
   [key: string]: any;
 }
 
-export type IMaybeError<T> = IValidateResult<T> | null;
+export type IMaybeError<T> = IValidateResult<T> | null | undefined;
 
 // prettier-ignore
 export enum ValidateOption {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -44,7 +44,7 @@ export interface IValidateResult<T> {
   [key: string]: any;
 }
 
-export type IMaybeError<T> = IValidateResult<T> | null | undefined;
+export type IMaybeError<T> = IValidateResult<T> | null;
 
 // prettier-ignore
 export enum ValidateOption {


### PR DESCRIPTION
表单联动时经常需要显示不同的字段，并且最后提交时需要根据当前视图中已渲染的组件来获取表单值，而destroyOnUnmount只在View策略生效，并且需要手动指定，`getVisibleValue`提供了一种仅获取视图中渲染的组件的值的方式