### PR TITLE
[WIP]fix: FieldSetValue使用不同的context

### DIFF
--- a/dev.tsx
+++ b/dev.tsx
@@ -93,8 +93,8 @@ const Input = ({ field }: { field: any; validators?: any[] }) => {
   );
 };
 
-const Input2 = ({ name, validators }: any) => {
-  const model = useField(name, '', validators);
+const Input2 = ({ name, validators, defaultValue }: any) => {
+  const model = useField(name, defaultValue || '', validators);
   const { error } = model;
   const onChange = useCallback(
     e => {
@@ -166,10 +166,23 @@ const App = () => {
   console.log('App render');
   return (
     <FormProvider value={form.ctx}>
-      <Input2
+      <Input2 name="field0" defaultValue="field0-value" />
+      <FieldSet name="set">
+        <Input2 name="field1" defaultValue="field1-value" />
+      </FieldSet>
+      <FieldSet name="set">
+        <Input2 name="field2" defaultValue="field2-value" />
+      </FieldSet>
+      <FieldSetValue name="set">
+        <FieldValue name="field1">{value => <span>field1: {value}</span>}</FieldValue>
+        <FieldValue name="field2">{value => <span>field2: {value}</span>}</FieldValue>
+        <Input2 name="field3" defaultValue="field3-value" />
+      </FieldSetValue>
+      <FieldValue name="field0">{value => <span>field0: {value}</span>}</FieldValue>
+      {/* <Input2
         name="name"
         validators={[
-          ValidatorMiddlewares.dynamicMessage(() => (Math.random() > 0.5 ? '> 0.5' : '< 0.5'))(Validators.required()),
+          ValidatorMiddlewares.message(() => (Math.random() > 0.5 ? '> 0.5' : '< 0.5'))(Validators.required()),
         ]}
       />
       <Input2
@@ -177,7 +190,7 @@ const App = () => {
         validators={[
           ValidatorMiddlewares.whenAsync(async () => Math.random() > 0.5)(Validators.required('required when > 0.5')),
         ]}
-      />
+      /> */}
       {/* {Array(1000)
         .fill()
         .map((_, index) => (
@@ -188,13 +201,13 @@ const App = () => {
         <FieldValue name="input1" />
         <Input field="input2" />
       </FieldSet> */}
-      <FieldSetValue name="fieldset">
+      {/* <FieldSetValue name="fieldset">
         <FieldValue name="input2" />
       </FieldSetValue>
       <List />
-      <NestedList1 model="nested-list" />
+      <NestedList1 model="nested-list" /> */}
       <div>
-        <button onClick={() => console.log(form.model.getRawValue())}>button</button>
+        <button onClick={() => console.log(form.model.getRawValue())}>get form value</button>
         <button
           onClick={() =>
             form.model

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react';
 import { FormStrategy, FormModel, FieldSetModel } from './models';
+import { isNil } from './utils';
 
 export interface IFormContext {
   strategy: FormStrategy;
@@ -16,9 +17,20 @@ export const FormProvider = FormContext.Provider;
 export function useFormContext(): IFormContext {
   const ctx = useContext(FormContext);
   if (ctx === null) {
-    throw new Error();
+    throw new Error('Cannot find FormContext.\nUse field component within Form.');
   }
   return ctx;
 }
 
 export default FormContext;
+
+export const ValueContext = createContext<IFormContext | null>(null);
+
+export function useValueContext(): IFormContext {
+  const formCtx = useContext(FormContext);
+  const valueCtx = useContext(ValueContext);
+  if (isNil(formCtx) && isNil(valueCtx)) {
+    throw new Error('Cannot find ValueContext.\n Use value component within Form');
+  }
+  return (valueCtx || formCtx) as IFormContext;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,7 @@ export function removeOnUnmount<Model extends BasicModel<any>>(
 }
 
 export type $MergeProps<T> = (T extends any ? (t: T) => void : never) extends (r: infer R) => void ? R : never;
+
+export function isNil(value: unknown) {
+  return value === null || value === void 0;
+}

--- a/src/value-listener.tsx
+++ b/src/value-listener.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { merge, never, of, Observable } from 'rxjs';
 import { filter, switchMap } from 'rxjs/operators';
-import { useFormContext, FormContext, IFormContext } from './context';
+import { useValueContext, ValueContext, IFormContext } from './context';
 import { useValue$ } from './hooks';
 import {
   FieldModel,
@@ -63,7 +63,7 @@ function getModelFromContext<Model>(
  * 根据 `name` 订阅 `FieldSet` 的值
  */
 export function FieldSetValue({ name, children }: IFieldSetValueProps) {
-  const ctx = useFormContext();
+  const ctx = useValueContext();
   const model = getModelFromContext(ctx, name, undefined, isFieldSetModel);
   const childContext = React.useMemo<IFormContext>(
     () => ({
@@ -74,9 +74,9 @@ export function FieldSetValue({ name, children }: IFieldSetValueProps) {
   );
   if (model) {
     return (
-      <FormContext.Provider key={model.id} value={childContext}>
+      <ValueContext.Provider key={model.id} value={childContext}>
         {children}
-      </FormContext.Provider>
+      </ValueContext.Provider>
     );
   }
   return null;
@@ -100,7 +100,7 @@ export interface IFieldValueModelDrivenProps<T> extends IFieldValueCommonProps<T
 export type IFieldValueProps<T> = IFieldValueModelDrivenProps<T> | IFieldValueViewDrivenProps<T>;
 
 export function useFieldValue<T>(field: string | FieldModel<T>): T | null {
-  const ctx = useFormContext();
+  const ctx = useValueContext();
   const [model, setModel] = React.useState<FieldModel<T> | ModelRef<T, any, FieldModel<T>> | null>(
     isFieldModel<T>(field) || isModelRef<T, any, FieldModel<T>>(field) ? field : null,
   );
@@ -165,7 +165,7 @@ export function FieldValue<T>(props: IFieldValueProps<T>): React.ReactElement | 
  * 根据 `name` 或者 `model` 订阅 `FieldArray` 的更新
  */
 export function useFieldArrayValue<Item, Child extends BasicModel<Item>>(field: string | FieldArrayModel<Item, Child>) {
-  const ctx = useFormContext();
+  const ctx = useValueContext();
   const model = getModelFromContext(
     ctx,
     field as string | undefined,


### PR DESCRIPTION
避免`FieldSetValue`内的字段被注册到`FieldSetValue`对应的`FieldSet`上

```tsx
<FieldSet name="set1">
  <Input2 name="field1" defaultValue="field1-value" />
</FieldSet>
<FieldSetValue name="set1">
  <FieldSet name="set2">
    <FieldValue name="field1">{value => <span>field1: {value}</span>}</FieldValue>
    <Input2 name="field2" defaultValue="field2-value" />
  </FieldSet>
</FieldSetValue>
```
当前版本在以上这种情况中会导致`set2`被挂到了`set1`对象上