### PR TITLE
[WIP]fix: no-op when patchValue receive undefined

### DIFF
--- a/src/models/array.ts
+++ b/src/models/array.ts
@@ -6,6 +6,7 @@ import { BasicBuilder } from '../builders/basic';
 import { or, Some } from '../maybe';
 import UniqueId from '../unique-id';
 import { IModel } from './base';
+import { isUndefined } from '../utils';
 
 const FIELD_ARRAY_ID = Symbol('field-array');
 
@@ -125,6 +126,11 @@ class FieldArrayModel<Item, Child extends IModel<Item> = IModel<Item>> extends B
         break;
       }
       const item = value[i];
+
+      if (isUndefined(item)) {
+        continue;
+      }
+
       const model = children[i];
       if (isModelRef(model)) {
         const m = model.getModel();

--- a/src/models/field.ts
+++ b/src/models/field.ts
@@ -2,7 +2,7 @@ import { BehaviorSubject } from 'rxjs';
 import { BasicModel } from './basic';
 import { Some, None, or, isSome, get } from '../maybe';
 import { ValidateOption } from '../validate';
-import { id } from '../utils';
+import { id, isUndefined } from '../utils';
 import UniqueId from '../unique-id';
 
 const FIELD_ID = Symbol('field');
@@ -110,7 +110,7 @@ class FieldModel<Value> extends BasicModel<Value> {
    * @param value 要设置的值
    */
   patchValue(value: Value) {
-    this.value$.next(value);
+    isUndefined(value) || this.value$.next(value);
   }
 
   /**

--- a/src/models/ref.ts
+++ b/src/models/ref.ts
@@ -131,7 +131,9 @@ class ModelRef<Value, Parent extends IModel<any>, Model extends IModel<Value>> i
   }
 
   patchValue(value: Value) {
-    isUndefined(value) || this.getModel()?.patchValue(value);
+    if (!isUndefined(value)) {
+      this.getModel()?.patchValue(value);
+    }
   }
 
   initialize(value: Value) {

--- a/src/models/ref.ts
+++ b/src/models/ref.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject } from 'rxjs';
 import { IModel } from './base';
 import { ValidateOption, IMaybeError, IValidators } from '../validate';
 import { Maybe, None } from '../maybe';
+import { isUndefined } from '../utils';
 
 const REF_ID = Symbol('ref');
 
@@ -130,7 +131,7 @@ class ModelRef<Value, Parent extends IModel<any>, Model extends IModel<Value>> i
   }
 
   patchValue(value: Value) {
-    this.getModel()?.patchValue(value);
+    isUndefined(value) || this.getModel()?.patchValue(value);
   }
 
   initialize(value: Value) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,7 @@ export function removeOnUnmount<Model extends BasicModel<any>>(
 }
 
 export type $MergeProps<T> = (T extends any ? (t: T) => void : never) extends (r: infer R) => void ? R : never;
+
+export function isUndefined(value: unknown): value is undefined {
+  return value === void 0;
+}


### PR DESCRIPTION
调用父级字段（`Set`、`Array`、`Form`）的`patchValue`时，由于参数是`Partial`的，因此各个Field有可能会接收到`undefined`，但是内部调用的`patchValue`躲过了类型检查，因此这里会出现类型不正确的情况。

体现在业务中就是调用`form.patchValue`时某个field值由于某种原因为`undefined`，此处不会提示类型错误，但访问`fieldModel.value`时出现了预期之外的`undefined`。