### PR TITLE
fix: IModel增加removeChild方法，在dispose时调用父级的removeChild

### DIFF
--- a/src/field-array.tsx
+++ b/src/field-array.tsx
@@ -2,7 +2,7 @@ import { useMemo, useEffect } from 'react';
 import { FieldArrayModel, FormStrategy, FieldSetModel, ModelRef, isModelRef, isFieldArrayModel } from './models';
 import { useFormContext } from './context';
 import { useValue$ } from './hooks';
-import { removeOnUnmount } from './utils';
+import { removeOnUnmount, isString } from './utils';
 import { isSome, get } from './maybe';
 import { IValidators } from './validate';
 import { IModel } from './models/base';
@@ -18,7 +18,7 @@ function useArrayModel<Item, Child extends IModel<Item>>(
   const { model, effect } = useMemo(() => {
     let model: FieldArrayModel<Item, Child>;
     let effect: (() => void) | undefined;
-    if (typeof field === 'string') {
+    if (isString(field)) {
       if (strategy !== FormStrategy.View) {
         throw new Error();
       }
@@ -97,7 +97,7 @@ export function useFieldArray<Item, Child extends IModel<Item>>(
 ): FieldArrayModel<Item, Child> {
   const { parent, strategy } = useFormContext();
   const model = useArrayModel(field, parent, strategy, defaultValue);
-  if (typeof field === 'string' || isModelRef(field)) {
+  if (isString(field) || isModelRef(field)) {
     model.validators = validators;
   }
   const { error$, children$ } = model;

--- a/src/field-set.tsx
+++ b/src/field-set.tsx
@@ -11,7 +11,7 @@ import {
 } from './models';
 import { useValue$ } from './hooks';
 import { IValidators } from './validate';
-import { isPlainObject, removeOnUnmount } from './utils';
+import { isPlainObject, removeOnUnmount, isString } from './utils';
 import { get, isSome, or } from './maybe';
 
 export type IUseFieldSet<T extends Record<string, BasicModel<any>>> = [IFormContext, FieldSetModel<T>];
@@ -24,7 +24,7 @@ function useFieldSetModel<T extends Record<string, BasicModel<any>>>(
   const { model, effect } = useMemo(() => {
     let model: FieldSetModel<any>;
     let effect: (() => void) | undefined;
-    if (typeof field === 'string') {
+    if (isString(field)) {
       if (strategy !== FormStrategy.View) {
         throw new Error();
       }
@@ -78,7 +78,7 @@ export function useFieldSet<T extends Record<string, BasicModel<any>>>(
 ): IUseFieldSet<T> {
   const { parent, strategy, form } = useFormContext();
   const model = useFieldSetModel(field, parent, strategy);
-  if (typeof field === 'string' || isModelRef(field)) {
+  if (isString(field) || isModelRef(field)) {
     model.validators = validators;
   }
   const childContext = useMemo(

--- a/src/field.tsx
+++ b/src/field.tsx
@@ -12,7 +12,7 @@ import {
 import { useValue$ } from './hooks';
 import { useFormContext } from './context';
 import { IValidators } from './validate';
-import { removeOnUnmount } from './utils';
+import { removeOnUnmount, isString } from './utils';
 import { or } from './maybe';
 
 function isValueFactory<Value>(candidate: Value | (() => Value)): candidate is () => Value {
@@ -29,7 +29,7 @@ function useModelAndChildProps<Value>(
   const { model, effect } = useMemo(() => {
     let model: FieldModel<Value>;
     let effect: (() => void) | undefined;
-    if (typeof field === 'string') {
+    if (isString(field)) {
       if (strategy !== FormStrategy.View) {
         throw new Error();
       }
@@ -96,7 +96,7 @@ export function useField<Value>(
   const { value$, error$ } = model;
   useValue$(value$, value$.getValue());
   useValue$(error$, error$.getValue());
-  if (typeof field === 'string' || isModelRef(field)) {
+  if (isString(field) || isModelRef(field)) {
     model.validators = validators;
   }
   removeOnUnmount(field, model, parent);

--- a/src/models/array.ts
+++ b/src/models/array.ts
@@ -11,7 +11,8 @@ const FIELD_ARRAY_ID = Symbol('field-array');
 
 const uniqueId = new UniqueId('field-array');
 
-class FieldArrayModel<Item, Child extends IModel<Item> = IModel<Item>> extends BasicModel<readonly Item[]> {
+class FieldArrayModel<Item, Child extends IModel<Item> = IModel<Item>> extends BasicModel<readonly Item[]>
+  implements IModel<readonly Item[]> {
   /**
    * @internal
    */
@@ -268,6 +269,11 @@ class FieldArrayModel<Item, Child extends IModel<Item> = IModel<Item>> extends B
       }
     }
     return false;
+  }
+
+  removeChild(model: Child) {
+    const index = this.children.indexOf(model);
+    return index > -1 ? this.splice(index, 1)[0] : null;
   }
 
   dispose() {

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -18,4 +18,5 @@ export interface IModel<Value> {
   form: FormModel<any> | null | undefined;
   dispose(): void;
   validators: IValidators<Value>;
+  removeChild?(field: IModel<any>): IModel<any> | null;
 }

--- a/src/models/basic.ts
+++ b/src/models/basic.ts
@@ -64,6 +64,8 @@ abstract class BasicModel<Value> implements IModel<Value> {
   dispose() {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
     this.subscriptions = [];
+    const { owner } = this;
+    owner?.removeChild?.(this);
     this.owner = null;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,8 @@ export function isPlainObject(value: unknown): value is object {
   return Object.getPrototypeOf(value) === proto;
 }
 
+export const isString = (value: unknown): value is string => typeof value === 'string';
+
 export function removeOnUnmount<Model extends BasicModel<any>>(
   field: string | BasicModel<any> | ModelRef<any, any, Model>,
   model: BasicModel<any>,
@@ -32,7 +34,7 @@ export function removeOnUnmount<Model extends BasicModel<any>>(
 ) {
   useEffect(
     () => () => {
-      if (typeof field === 'string' && model.destroyOnUnmount) {
+      if (isString(field) && model.destroyOnUnmount) {
         parent.removeChild(field);
       }
     },

--- a/src/value-listener.tsx
+++ b/src/value-listener.tsx
@@ -13,7 +13,7 @@ import {
   isModelRef,
   ModelRef,
 } from './models';
-import { noop, $MergeProps } from './utils';
+import { noop, $MergeProps, isString } from './utils';
 
 export interface IFieldSetValueProps {
   name: string;
@@ -28,7 +28,7 @@ function getModelFromContext<Model>(
 ): Model | null {
   const { parent } = ctx;
   const m = React.useMemo(() => {
-    if (typeof name === 'string') {
+    if (isString(name)) {
       const m = parent.get(name);
       if (check(m)) {
         return m;


### PR DESCRIPTION
`BasicModel#dispose`对标`HTMLElement#remove`

顺便把typeof xxx === 'string'替换为isString(xxx)