### PR TITLE
fix: 修复removeOnUnmount中的依赖数组

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ export function removeOnUnmount<Model extends BasicModel<any>>(
         parent.removeChild(field);
       }
     },
-    [field, model, model],
+    [field, model, parent],
   );
 }
 


### PR DESCRIPTION
错误的依赖数组在某些情况下会抛出错误